### PR TITLE
Fix CI: deploy website by PRs against main, v1, and v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ name: anoma-spec-ci
   pull_request:
     branches:
       - main
+      - v1
+      - v2
     types:
       - opened
       - reopened


### PR DESCRIPTION
This PR fixes the CI workflow to deploy on PR against v1, v2, and, as before, against the main.

- Closes #76 