### PR TITLE
Remove polyfill.js from the external dependencies

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -556,7 +556,6 @@ extra_javascript:
   - assets/js/extra.js
   - assets/js/highlight.js
   - assets/js/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3.0.0/es5/tex-svg.js
 # See https://squidfunk.github.io/mkdocs-material/reference/math/?h=katex#comparing-mathjax-and-katex on why we use MathJax
 markdown_extensions:


### PR DESCRIPTION
After checking the sources, I see that this external script is really unnecessary. Also, mkdocs-material seems to have solved this dependency some time ago.

So thanks @tg-x for the finding this:

- https://www.theregister.com/2024/06/25/polyfillio_china_crisis/