### PR TITLE
Revert "Engines: EngineEnv revision"

### DIFF
--- a/.changelog/unreleased/fixes/types/243-types243.md
+++ b/.changelog/unreleased/fixes/types/243-types243.md
@@ -1,1 +1,0 @@
-  -  [**#243**](https://github.com/anoma/nspec/pull/243): Refactor `EngineEnv` type, rename from `EngineEnvironment`, add `node` field, and remove `name` field from `Engine` since it's already in `EngineEnv`.

--- a/docs/arch/node/types/engine.juvix.md
+++ b/docs/arch/node/types/engine.juvix.md
@@ -43,7 +43,8 @@ Each engine, not its type, is associated with:
 
 ```juvix
 type Engine (S M H A L X : Type) := mkEngine {
-  initEnv : EngineEnv S M H;
+  name : EngineName;
+  initEnv : EngineEnvironment S M H;
   behaviour : EngineBehaviour S M H A L X;
 };
 ```

--- a/docs/arch/node/types/engine_environment.juvix.md
+++ b/docs/arch/node/types/engine_environment.juvix.md
@@ -16,6 +16,7 @@ tags:
     import arch.node.types.basics open public;
     import arch.node.types.identities open;
     import arch.node.types.messages open;
+    import arch.node.types.anoma_message as Anoma;
     ```
 
 # Engine environment type
@@ -31,7 +32,7 @@ instances in the following categories:
   name.
 - A list of timers that have been set.
 
-This data is encapsulated within the `EngineEnv` type, which is
+This data is encapsulated within the `EngineEnvironment` type, which is
 parameterised by four types:
 
 - `S`, representing the local state,
@@ -42,10 +43,9 @@ These same letters will be used in the rest of the document to represent these
 types.
 
 ```juvix
-type EngineEnv (S M H : Type) :=
-  mkEngineEnv {
-      node : NodeID; -- local NodeID, read-only
-      name : EngineName ; -- local EngineName, read-only
+type EngineEnvironment (S M H : Type) :=
+  mkEngineEnvironment {
+      name : EngineName ; -- read-only
       localState : S;
       mailboxCluster : Map MailboxID (Mailbox M);
       acquaintances : Set EngineName;


### PR DESCRIPTION
Reverts anoma/nspec#243. The changes in this pull request broke typechecking and required for new engine
definitions to establish a node ID, which is not known. 

- Also, a change like this requires us to update all the existing engine definitions, and these changes are not included in the original PR, but they should.