### PR TITLE
Rename `resourceLogicProofs` to `logicVerifierInputs`

### DIFF
--- a/docs/arch/system/state/resource_machine/data_structures/action/index.juvix.md
+++ b/docs/arch/system/state/resource_machine/data_structures/action/index.juvix.md
@@ -25,7 +25,7 @@ An action is a composite structure of type `Action` that contains the following 
 Actions partition the state change induced by a transaction and limit the evaluation context of resource logics: proofs created in the context of an action have access only to the resources associated with the action. A resource is said to be *associated with an action* if its tag is a key of the `logicVerifierInputs` map. A resource is associated with at most two actions: resource creation is associated with exactly one action and resource consumption is associated with exactly one action. A resource is said to be *consumed in the action* for a valid action if its *nullifier* is a key of the `logicVerifierInputs` map. A resource is said to be *created in the action* for a valid action if its *commitment* is a key of the `logicVerifierInputs` map.
 
 !!! note
-    Unlike transactions, actions may be unbalanced; however, if an action is valid and balanced, it is sufficient to create a balanced transaction with only this one action.
+    Unlike transactions, actions don't need to be balanced, but if an action is valid and balanced, it is sufficient to create a balanced transaction.
 
 ## Interface
 


### PR DESCRIPTION
The name `resourceLogicProofs` seems sub-optimal in that it does not only contain resource logic proofs, but also other data. In general, the principle of _[pars pro toto](https://en.wikipedia.org/wiki/Pars_pro_toto)_ applies to naming; however, in this case, @heueristik and me share the opinion that `logicVerifierInputs` is more descriptive and thus preferable. 

The prose is adapted accordingly; I have also taken the liberty to make some other minor changes to the prose. 
