### PR TITLE
refactor(docs): reorganize navigation in mkdocs.yml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,7 +68,7 @@ repos:
         entry: python -c "import sys, re; sys.exit(1 if any(not re.match(r'^[a-z0-9_.-]+$', f.split('/')[-1]) for f in sys.argv[1:]) else 0)"
         language: python
         types: [file]
-        exclude: '.pre-commit.*|^overrides.*|^docs/(assets|images)/|^formal.*|.*Package.juvix.*|^\.github/.*|CITATION|LICENSE|Makefile|README\.md|VERSION|.changelog/.*'
+        exclude: '\.git/|\.pre-commit.*|^overrides.*|^docs/(assets|images)/|^formal.*|.*Package\.juvix.*|^\.github/.*|CITATION|LICENSE|Makefile|README\.md|VERSION|\.changelog/.*'
 
       - id: typecheck
         name: typecheck

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,15 +11,13 @@ edit_uri: edit/main/docs/
 use_directory_urls: false
 nav:
   - Home: index.md
+  - Anoma architecture: ./arch/overview.md
   - Changelog: ./changelog.md
   - Indexes:
       - List of tags: ./indexes/tags.md
       - List of modules: ./indexes/modules.md
       - List of basic types: ./prelude.juvix.md
         #   - List of engines: ./indexes/engines.md
-  - Introduction:
-      - Anomian: ./anomian.juvix.md
-      - Anoma architecture: ./arch/overview.md
   - Node architecture:
       - Concepts:
           - Engine: ./arch/node/concepts/engine.md
@@ -230,6 +228,7 @@ nav:
           - ./arch/integrations/adapters/index.md
           - Ethereum Virtual Machine: ./arch/integrations/adapters/evm.md
   - Tutorials:
+      - Anomian: ./anomian.juvix.md
       - Contributor guidelines:
           - Global principles and guidelines: ./tutorial/principles_and_guidelines.md
           - Prepare working environment: ./tutorial/install/index.md


### PR DESCRIPTION
- Moved "Anoma architecture" to the main navigation level and "Anomian" under the "Tutorials" section for improved clarity and accessibility. This change aims to streamline the documentation structure, making key sections easier to locate.
- Fixes typo in hook ID and excludes .git/ files from filename validation