### PR TITLE
Fix typos in Juvix documentation

### DIFF
--- a/docs/arch/node/engines/mempool_worker_behaviour.juvix.md
+++ b/docs/arch/node/engines/mempool_worker_behaviour.juvix.md
@@ -139,7 +139,7 @@ A mempool worker acts as a transaction coordinator, receiving transaction reques
        - `executor`: ID of spawned executor
        - `timestamp`: Generated fingerprint
 
-5. **Replys and Effects**
+5. **Replies and Effects**
    - **Reply Delivery**
      - All messages are sent with mailbox 0 (default response mailbox).
      - Transaction acknowledgment is sent back to original requester.

--- a/docs/arch/system/identity/identity.juvix.md
+++ b/docs/arch/system/identity/identity.juvix.md
@@ -299,7 +299,7 @@ Likewise, its `DecryptorType` should be the type of objects that can decrypt
  `EncryptorType`.
 Implementations should ultimately include, for example,
  [RSA](https://en.wikipedia.org/wiki/RSA_(cryptosystem))
- public / private keys sytems.
+ public / private keys systems.
 
 An Identity includes:
 


### PR DESCRIPTION


This PR corrects minor spelling errors in the Juvix documentation files.

### Changes:
- **`mempool_worker_behaviour.juvix.md`**: Fixed "Replys" → "Replies"
- **`identity.juvix.md`**: Fixed "sytems" → "systems"

